### PR TITLE
feat(auth): remove interests step from owner registration

### DIFF
--- a/.idea/caches/deviceStreaming.xml
+++ b/.idea/caches/deviceStreaming.xml
@@ -88,6 +88,19 @@
           <option name="screenY" value="2160" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="Lenovo" />
+          <option name="codename" value="TB330FU" />
+          <option name="formFactor" value="Tablet" />
+          <option name="id" value="TB330FU" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Lenovo" />
+          <option name="name" value="Tab M11" />
+          <option name="screenDensity" value="240" />
+          <option name="screenX" value="1200" />
+          <option name="screenY" value="1920" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="a14m" />
@@ -218,6 +231,18 @@
           <option name="screenDensity" value="340" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2640" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="google" />
+          <option name="codename" value="blazer" />
+          <option name="id" value="blazer" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 10 Pro" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2410" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="32" />
@@ -367,18 +392,6 @@
           <option name="screenY" value="384" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
-          <option name="api" value="35" />
-          <option name="brand" value="motorola" />
-          <option name="codename" value="eqe" />
-          <option name="id" value="eqe" />
-          <option name="labId" value="google" />
-          <option name="manufacturer" value="Motorola" />
-          <option name="name" value="edge 50 pro" />
-          <option name="screenDensity" value="450" />
-          <option name="screenX" value="1220" />
-          <option name="screenY" value="2712" />
-        </PersistentDeviceSelectionData>
-        <PersistentDeviceSelectionData>
           <option name="api" value="33" />
           <option name="brand" value="google" />
           <option name="codename" value="felix" />
@@ -437,6 +450,18 @@
           <option name="screenDensity" value="280" />
           <option name="screenX" value="720" />
           <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="google" />
+          <option name="codename" value="frankel" />
+          <option name="id" value="frankel" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 10" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2424" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
@@ -561,6 +586,18 @@
           <option name="screenY" value="1600" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="kansas" />
+          <option name="id" value="kansas" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g - 2025" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1604" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="google" />
           <option name="codename" value="komodo" />
@@ -643,6 +680,18 @@
           <option name="screenDensity" value="280" />
           <option name="screenX" value="720" />
           <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="google" />
+          <option name="codename" value="mustang" />
+          <option name="id" value="mustang" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 10 Pro XL" />
+          <option name="screenDensity" value="390" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2404" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />

--- a/.idea/copilot.data.migration.ask.xml
+++ b/.idea/copilot.data.migration.ask.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AskMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.ask2agent.xml
+++ b/.idea/copilot.data.migration.ask2agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Ask2AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/app/src/main/java/uvg/edu/tripwise/DavidActivity.kt
+++ b/app/src/main/java/uvg/edu/tripwise/DavidActivity.kt
@@ -1,4 +1,0 @@
-package uvg.edu.tripwise
-
-import androidx.compose.runtime.Composable
-

--- a/app/src/main/java/uvg/edu/tripwise/auth/RegisterActivity.kt
+++ b/app/src/main/java/uvg/edu/tripwise/auth/RegisterActivity.kt
@@ -114,7 +114,7 @@ fun RegisterScreen(
     }
 
     fun getMaxSteps(): Int {
-        return if (selectedRole == "owner") 4 else 3
+        return if (selectedRole == "owner") 3 else 3
     }
 
     fun mapPropertyType(frontendType: String): String {
@@ -285,16 +285,6 @@ fun RegisterScreen(
                 }
             }
 
-            3 -> {
-                if (selectedRole == "owner") {
-                    InterestsScreen(
-                        selectedInterests = selectedInterests,
-                        onInterestsChanged = { selectedInterests = it },
-                        totalSteps = getMaxSteps(),
-                        modifier = Modifier.fillMaxSize()
-                    )
-                }
-            }
         }
 
         LinearProgressIndicator(


### PR DESCRIPTION
Removes the interests selection step from the owner registration flow, simplifying it from 4 to 3 steps. Also deletes the unused `DavidActivity.kt` file.

## Description
This pull request updates device streaming configurations and registration logic, and removes unused files in the project. The most significant changes are new device entries for testing, updates to registration steps, and cleanup of unused code and migration status files.

## Related Issue
<!-- Example: Closes #12 -->
Closes #

## Type of Change
- [ ] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor
- [ ] ⚙️ Chore

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] My code follows the project’s coding standards
- [ ] I have added tests to prove my fix/feature works
- [ ] I have updated documentation if needed
- [ ] No new warnings or errors were introduced
