### PR TITLE
refactor(admin): Enhance User and Property Detail Screens

### DIFF
--- a/.idea/caches/deviceStreaming.xml
+++ b/.idea/caches/deviceStreaming.xml
@@ -343,6 +343,18 @@
           <option name="screenY" value="1080" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="dm1q" />
+          <option name="id" value="dm1q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="S23" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="dm2q" />
@@ -764,6 +776,18 @@
           <option name="screenDensity" value="420" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="psq" />
+          <option name="id" value="psq" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S25 Edge" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3120" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />

--- a/app/src/main/java/uvg/edu/tripwise/admin/CommonComposables.kt
+++ b/app/src/main/java/uvg/edu/tripwise/admin/CommonComposables.kt
@@ -1,0 +1,92 @@
+package uvg.edu.tripwise.admin
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+/**
+ * Un Composable común para mostrar una fila de información con etiqueta y valor.
+ */
+@Composable
+fun InfoRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            fontSize = 14.sp,
+            color = Color.Gray,
+            fontWeight = FontWeight.Medium
+        )
+        Text(
+            text = value,
+            fontSize = 14.sp,
+            color = Color.Black
+        )
+    }
+}
+
+/**
+ * (NUEVO)
+ * Un Composable reutilizable para campos 'enum' que usa un dropdown.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EnumDropdownSelector(
+    label: String,
+    options: List<String>,
+    selectedOption: String,
+    onOptionSelected: (String) -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = isExpanded,
+        onExpandedChange = { isExpanded = !isExpanded },
+        modifier = modifier
+    ) {
+        OutlinedTextField(
+            value = selectedOption,
+            onValueChange = {}, // El valor se cambia desde el menú
+            readOnly = true,
+            label = { Text(label) },
+            trailingIcon = {
+                ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpanded)
+            },
+            colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(), // Importante para anclar el menú
+            enabled = enabled
+        )
+
+        ExposedDropdownMenu(
+            expanded = isExpanded,
+            onDismissRequest = { isExpanded = false }
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option.replaceFirstChar { it.uppercase() }) },
+                    onClick = {
+                        onOptionSelected(option)
+                        isExpanded = false
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/uvg/edu/tripwise/admin/PropertyDetailActivity.kt
+++ b/app/src/main/java/uvg/edu/tripwise/admin/PropertyDetailActivity.kt
@@ -1,11 +1,13 @@
 package uvg.edu.tripwise.admin
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -14,13 +16,16 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
 import uvg.edu.tripwise.data.model.Property
 import uvg.edu.tripwise.data.repository.PropertyRepository
 import uvg.edu.tripwise.ui.theme.TripWiseTheme
+import uvg.edu.tripwise.network.UpdatePropertyRequest
 
 class PropertyDetailActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,18 +44,69 @@ class PropertyDetailActivity : ComponentActivity() {
 fun PropertyDetailScreen(propertyId: String, onBack: () -> Unit) {
     var property by remember { mutableStateOf<Property?>(null) }
     var isLoading by remember { mutableStateOf(true) }
+    var isSaving by remember { mutableStateOf(false) }
+
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
     val propertyRepository = remember { PropertyRepository() }
+
+    // Estados para los campos editables
+    var name by remember { mutableStateOf("") }
+    var location by remember { mutableStateOf("") }
+    var propertyType by remember { mutableStateOf("") }
+    var pricePerNight by remember { mutableStateOf("") }
+    var capacity by remember { mutableStateOf("") }
+    var approved by remember { mutableStateOf("") }
 
     LaunchedEffect(propertyId) {
         scope.launch {
             try {
-                val properties = propertyRepository.getProperties()
-                property = properties.find { it.id == propertyId }
+                isLoading = true
+                val prop = propertyRepository.getPropertyById(propertyId)
+                property = prop
+
+                name = prop.name
+                location = prop.location
+                propertyType = prop.propertyType
+                pricePerNight = prop.pricePerNight.toString()
+                capacity = prop.capacity.toString()
+                approved = prop.approved
             } catch (e: Exception) {
-                // Manejar error
+                Toast.makeText(context, "Error al cargar la propiedad", Toast.LENGTH_SHORT).show()
             } finally {
                 isLoading = false
+            }
+        }
+    }
+
+    fun onSaveChanges() {
+        val currentProperty = property ?: return
+
+        scope.launch {
+            isSaving = true
+            try {
+                val request = UpdatePropertyRequest(
+                    name = name,
+                    description = currentProperty.description,
+                    location = location,
+                    pricePerNight = pricePerNight.toDoubleOrNull() ?: currentProperty.pricePerNight,
+                    capacity = capacity.toIntOrNull() ?: currentProperty.capacity,
+                    pictures = currentProperty.pictures,
+                    amenities = currentProperty.amenities,
+                    propertyType = propertyType, // <-- Se usan los estados actualizados
+                    approved = approved, // <-- Se usan los estados actualizados
+                    latitude = currentProperty.latitude,
+                    longitude = currentProperty.longitude
+                )
+
+                propertyRepository.updateProperty(currentProperty.id, request)
+                Toast.makeText(context, "Propiedad actualizada", Toast.LENGTH_SHORT).show()
+                onBack()
+
+            } catch (e: Exception) {
+                Toast.makeText(context, "Error al guardar: ${e.message}", Toast.LENGTH_LONG).show()
+            } finally {
+                isSaving = false
             }
         }
     }
@@ -73,30 +129,58 @@ fun PropertyDetailScreen(propertyId: String, onBack: () -> Unit) {
     ) { innerPadding ->
         if (isLoading) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding),
+                modifier = Modifier.fillMaxSize().padding(innerPadding),
                 contentAlignment = Alignment.Center
             ) {
                 CircularProgressIndicator(color = Color(0xFF2563EB))
             }
         } else if (property == null) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding),
+                modifier = Modifier.fillMaxSize().padding(innerPadding),
                 contentAlignment = Alignment.Center
             ) {
                 Text("Property not found", color = Color.Gray)
             }
         } else {
-            PropertyDetailContent(property = property!!, modifier = Modifier.padding(innerPadding))
+            PropertyDetailContent(
+                modifier = Modifier.padding(innerPadding),
+                propertyId = property!!.id,
+                name = name,
+                onNameChange = { name = it },
+                location = location,
+                onLocationChange = { location = it },
+                propertyType = propertyType,
+                onPropertyTypeChange = { propertyType = it }, // <-- CAMBIO: Pasamos el setter
+                pricePerNight = pricePerNight,
+                onPricePerNightChange = { pricePerNight = it },
+                capacity = capacity,
+                onCapacityChange = { capacity = it },
+                approved = approved,
+                onApprovedChange = { approved = it }, // <-- CAMBIO: Pasamos el setter
+                isSaving = isSaving,
+                onSaveClick = { onSaveChanges() }
+            )
         }
     }
 }
 
 @Composable
-fun PropertyDetailContent(property: Property, modifier: Modifier = Modifier) {
+fun PropertyDetailContent(
+    modifier: Modifier = Modifier,
+    propertyId: String,
+    name: String, onNameChange: (String) -> Unit,
+    location: String, onLocationChange: (String) -> Unit,
+    propertyType: String, onPropertyTypeChange: (String) -> Unit, // <-- CAMBIO
+    pricePerNight: String, onPricePerNightChange: (String) -> Unit,
+    capacity: String, onCapacityChange: (String) -> Unit,
+    approved: String, onApprovedChange: (String) -> Unit, // <-- CAMBIO
+    isSaving: Boolean,
+    onSaveClick: () -> Unit
+) {
+    // Opciones basadas en tu property.model.js
+    val typeOptions = listOf("house", "apartment", "villa", "cottage", "hotel")
+    val statusOptions = listOf("pending", "approved", "rejected")
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -106,19 +190,13 @@ fun PropertyDetailContent(property: Property, modifier: Modifier = Modifier) {
     ) {
         Card(
             shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = Color.White)
+            colors = CardDefaults.cardColors(containerColor = Color(0xFFF1F5F9))
         ) {
             Column(
                 modifier = Modifier.padding(20.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                InfoRow(label = "Name", value = property.name)
-                InfoRow(label = "Location", value = property.location)
-                InfoRow(label = "Type", value = property.propertyType)
-                InfoRow(label = "Price per Night", value = "$${property.pricePerNight}")
-                InfoRow(label = "Capacity", value = "${property.capacity} guests")
-                InfoRow(label = "Status", value = property.approved.replaceFirstChar { it.uppercase() })
-                InfoRow(label = "Property ID", value = property.id)
+                InfoRow(label = "Property ID", value = propertyId)
             }
         }
 
@@ -129,13 +207,79 @@ fun PropertyDetailContent(property: Property, modifier: Modifier = Modifier) {
             color = Color.Black
         )
 
-        Button(
-            onClick = { /* TODO: Save changes */ },
+        // Campos Editables
+        OutlinedTextField(
+            value = name,
+            onValueChange = onNameChange,
+            label = { Text("Name") },
             modifier = Modifier.fillMaxWidth(),
+            enabled = !isSaving
+        )
+        OutlinedTextField(
+            value = location,
+            onValueChange = onLocationChange,
+            label = { Text("Location") },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !isSaving
+        )
+
+        // --- CAMBIO: De TextField a Dropdown ---
+        EnumDropdownSelector(
+            label = "Type",
+            options = typeOptions,
+            selectedOption = propertyType,
+            onOptionSelected = onPropertyTypeChange,
+            enabled = !isSaving
+        )
+        // --- FIN DEL CAMBIO ---
+
+        OutlinedTextField(
+            value = pricePerNight,
+            onValueChange = onPricePerNightChange,
+            label = { Text("Price per Night") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !isSaving
+        )
+        OutlinedTextField(
+            value = capacity,
+            onValueChange = onCapacityChange,
+            label = { Text("Capacity") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !isSaving
+        )
+
+        // --- CAMBIO: De TextField a Dropdown ---
+        EnumDropdownSelector(
+            label = "Status",
+            options = statusOptions,
+            selectedOption = approved,
+            onOptionSelected = onApprovedChange,
+            enabled = !isSaving
+        )
+        // --- FIN DEL CAMBIO ---
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+            onClick = onSaveClick,
+            enabled = !isSaving,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(50.dp),
             shape = RoundedCornerShape(8.dp),
             colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2563EB))
         ) {
-            Text("Save Changes", color = Color.White)
+            if (isSaving) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    color = Color.White,
+                    strokeWidth = 3.dp
+                )
+            } else {
+                Text("Save Changes", color = Color.White)
+            }
         }
     }
 }

--- a/app/src/main/java/uvg/edu/tripwise/admin/UserDetailActivity.kt
+++ b/app/src/main/java/uvg/edu/tripwise/admin/UserDetailActivity.kt
@@ -2,6 +2,7 @@ package uvg.edu.tripwise.admin
 
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.*
@@ -10,11 +11,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ExitToApp
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -22,7 +25,6 @@ import kotlinx.coroutines.launch
 import uvg.edu.tripwise.MainActivity
 import uvg.edu.tripwise.data.model.User
 import uvg.edu.tripwise.data.repository.UserRepository
-import uvg.edu.tripwise.ui.components.LogoAppTopBar
 import uvg.edu.tripwise.ui.theme.TripWiseTheme
 
 class UserDetailActivity : ComponentActivity() {
@@ -33,6 +35,7 @@ class UserDetailActivity : ComponentActivity() {
             TripWiseTheme {
                 UserDetailScreen(userId = userId, onBack = { finish() }, onLogout = {
                     val intent = Intent(this, MainActivity::class.java)
+                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                     startActivity(intent)
                     finish()
                 })
@@ -46,53 +49,130 @@ class UserDetailActivity : ComponentActivity() {
 fun UserDetailScreen(userId: String, onBack: () -> Unit, onLogout: () -> Unit = {}) {
     var user by remember { mutableStateOf<User?>(null) }
     var isLoading by remember { mutableStateOf(true) }
+    var isSaving by remember { mutableStateOf(false) }
+
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
     val userRepository = remember { UserRepository() }
+
+    // Estados para los campos editables
+    var name by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+    var role by remember { mutableStateOf("") } // <-- CAMBIO: Añadido estado para rol
 
     LaunchedEffect(userId) {
         scope.launch {
             try {
-                val users = userRepository.getUsers()
-                user = users.find { it.id == userId }
+                isLoading = true
+                val u = userRepository.getUserById(userId)
+                user = u
+
+                // Inicializar estados
+                name = u.name
+                email = u.email
+                role = u.role ?: "user" // <-- CAMBIO: Inicializar rol (default 'user' si es null)
             } catch (e: Exception) {
-                // Manejar error
+                Toast.makeText(context, "Error al cargar el usuario", Toast.LENGTH_SHORT).show()
             } finally {
                 isLoading = false
             }
         }
     }
 
+    fun onSaveChanges() {
+        val currentUser = user ?: return
+
+        scope.launch {
+            isSaving = true
+            try {
+                // Pasamos el 'role' a la función de update
+                userRepository.updateUser(
+                    id = currentUser.id,
+                    name = name,
+                    email = email,
+                    pfp = currentUser.pfp,
+                    role = role, // <-- CAMBIO: Pasamos el nuevo rol
+                    interests = currentUser.interests
+                )
+                Toast.makeText(context, "Usuario actualizado", Toast.LENGTH_SHORT).show()
+                onBack() // Regresar
+
+            } catch (e: Exception) {
+                Toast.makeText(context, "Error al guardar: ${e.message}", Toast.LENGTH_LONG).show()
+            } finally {
+                isSaving = false
+            }
+        }
+    }
+
     Scaffold(
         topBar = {
-            LogoAppTopBar(onLogout)
+            CenterAlignedTopAppBar(
+                title = { Text("User Details") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onLogout) {
+                        Icon(Icons.Default.ExitToApp, contentDescription = "Logout")
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = Color.White,
+                    titleContentColor = Color.Black
+                )
+            )
         }
     ) { innerPadding ->
         if (isLoading) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding),
+                modifier = Modifier.fillMaxSize().padding(innerPadding),
                 contentAlignment = Alignment.Center
             ) {
                 CircularProgressIndicator(color = Color(0xFF2563EB))
             }
         } else if (user == null) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding),
+                modifier = Modifier.fillMaxSize().padding(innerPadding),
                 contentAlignment = Alignment.Center
             ) {
                 Text("User not found", color = Color.Gray)
             }
         } else {
-            UserDetailContent(user = user!!, modifier = Modifier.padding(innerPadding))
+            UserDetailContent(
+                modifier = Modifier.padding(innerPadding),
+                user = user!!,
+                name = name,
+                onNameChange = { name = it },
+                email = email,
+                onEmailChange = { email = it },
+                role = role, // <-- CAMBIO: Pasamos el estado
+                onRoleChange = { role = it }, // <-- CAMBIO: Pasamos el setter
+                isSaving = isSaving,
+                onSaveClick = { onSaveChanges() }
+            )
         }
     }
 }
 
 @Composable
-fun UserDetailContent(user: User, modifier: Modifier = Modifier) {
+fun UserDetailContent(
+    modifier: Modifier = Modifier,
+    user: User,
+    name: String,
+    onNameChange: (String) -> Unit,
+    email: String,
+    onEmailChange: (String) -> Unit,
+    role: String, // <-- CAMBIO: Parámetro añadido
+    onRoleChange: (String) -> Unit, // <-- CAMBIO: Parámetro añadido
+    isSaving: Boolean,
+    onSaveClick: () -> Unit
+) {
+    // Opciones de rol basadas en tu user.model.js
+    val roleOptions = listOf("user", "owner", "admin")
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -100,18 +180,18 @@ fun UserDetailContent(user: User, modifier: Modifier = Modifier) {
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
+        // Card con información no editable
         Card(
             shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = Color.White)
+            colors = CardDefaults.cardColors(containerColor = Color(0xFFF1F5F9))
         ) {
             Column(
                 modifier = Modifier.padding(20.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                InfoRow(label = "Name", value = user.name)
-                InfoRow(label = "Email", value = user.email)
-                InfoRow(label = "Status", value = if (user.deleted?.isDeleted == true) "Inactive" else "Active")
                 InfoRow(label = "User ID", value = user.id)
+                InfoRow(label = "Status", value = if (user.deleted?.isDeleted == true) "Inactive" else "Active")
+                // InfoRow(label = "Role", value = user.role ?: "N/A") // Ya no es necesario, se edita abajo
             }
         }
 
@@ -122,33 +202,53 @@ fun UserDetailContent(user: User, modifier: Modifier = Modifier) {
             color = Color.Black
         )
 
-        Button(
-            onClick = { /* TODO: Save changes */ },
+        // Campos editables
+        OutlinedTextField(
+            value = name,
+            onValueChange = onNameChange,
+            label = { Text("Name") },
             modifier = Modifier.fillMaxWidth(),
+            enabled = !isSaving
+        )
+
+        OutlinedTextField(
+            value = email,
+            onValueChange = onEmailChange,
+            label = { Text("Email") },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !isSaving
+        )
+
+        // --- CAMBIO: De TextField a Dropdown ---
+        EnumDropdownSelector(
+            label = "Role",
+            options = roleOptions,
+            selectedOption = role,
+            onOptionSelected = onRoleChange,
+            enabled = !isSaving
+        )
+        // --- FIN DEL CAMBIO ---
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+            onClick = onSaveClick,
+            enabled = !isSaving,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(50.dp),
             shape = RoundedCornerShape(8.dp),
             colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF2563EB))
         ) {
-            Text("Save Changes", color = Color.White)
+            if (isSaving) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    color = Color.White,
+                    strokeWidth = 3.dp
+                )
+            } else {
+                Text("Save Changes", color = Color.White)
+            }
         }
-    }
-}
-
-@Composable
-fun InfoRow(label: String, value: String) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Text(
-            text = label,
-            fontSize = 14.sp,
-            color = Color.Gray,
-            fontWeight = FontWeight.Medium
-        )
-        Text(
-            text = value,
-            fontSize = 14.sp,
-            color = Color.Black
-        )
     }
 }

--- a/app/src/main/java/uvg/edu/tripwise/data/repository/UserRepository.kt
+++ b/app/src/main/java/uvg/edu/tripwise/data/repository/UserRepository.kt
@@ -54,86 +54,51 @@ class UserRepository {
     }
 
 
-        suspend fun updateUser(id: String, name: String?, email: String, pfp: String?, interests: List<String>?): User {
+    // --- FUNCIÓN 'updateUser' CORREGIDA ---
+    // Ahora acepta 'role' como parámetro
+    suspend fun updateUser(
+        id: String,
+        name: String?,
+        email: String,
+        pfp: String?,
+        role: String?, // <-- CAMBIO: Parámetro añadido
+        interests: List<String>?
+    ): User {
 
+        // Pasamos el 'role' al request
+        val req = UpdateUserRequest(
+            name = name,
+            email = email,
+            pfp = pfp,
+            role = role, // <-- CAMBIO: Parámetro añadido
+            interests = interests
+        )
 
-            val req = UpdateUserRequest(name = name, email = email, pfp = pfp, interests = interests)
+        val u = api.updateUser(id, req)
 
+        return User(
+            id = u.id,
+            name = u.name,
+            email = u.email,
+            pfp = u.pfp,
+            role = u.role,
+            properties = u.properties,
+            bookings = u.bookings,
+            itineraries = u.itineraries,
+            moneyProperty = u.moneyProperty,
+            moneyItinerary = u.moneyItinerary,
+            interests = u.interests,
+            createdAt = u.createdAt,
+            deleted = u.deleted?.let { d -> Deleted(isDeleted = d.isDeleted, at = d.at) }
+        )
+    }
 
-            val u = api.updateUser(id, req)
-
-
-            return User(
-
-
-                id = u.id,
-
-
-                name = u.name,
-
-
-                email = u.email,
-
-
-                pfp = u.pfp,
-
-
-                role = u.role,
-
-
-                properties = u.properties,
-
-
-                bookings = u.bookings,
-
-
-                itineraries = u.itineraries,
-
-
-                moneyProperty = u.moneyProperty,
-
-
-                moneyItinerary = u.moneyItinerary,
-
-
-                interests = u.interests,
-
-
-                createdAt = u.createdAt,
-
-
-                deleted = u.deleted?.let { d -> Deleted(isDeleted = d.isDeleted, at = d.at) }
-
-
-            )
-
-
+    suspend fun updatePassword(id: String, currentPassword: String, newPassword: String): Boolean {
+        return try {
+            val response = api.updatePassword(id, UpdatePasswordRequest(currentPassword, newPassword))
+            response.isSuccessful
+        } catch (e: Exception) {
+            false
         }
-
-
-    
-
-
-        suspend fun updatePassword(id: String, currentPassword: String, newPassword: String): Boolean {
-
-
-            return try {
-
-
-                val response = api.updatePassword(id, UpdatePasswordRequest(currentPassword, newPassword))
-
-
-                response.isSuccessful
-
-
-            } catch (e: Exception) {
-
-
-                false
-
-
-            }
-
-
-        }
+    }
 }

--- a/app/src/main/java/uvg/edu/tripwise/data/repository/propertyRepository.kt
+++ b/app/src/main/java/uvg/edu/tripwise/data/repository/propertyRepository.kt
@@ -4,13 +4,15 @@ import uvg.edu.tripwise.data.model.Deleted
 import uvg.edu.tripwise.data.model.Property
 import uvg.edu.tripwise.network.ApiProperty
 import uvg.edu.tripwise.network.CreatePropertyRequest
+// ¡Asegúrate de crear esta clase! (Ver nota al final)
+import uvg.edu.tripwise.network.UpdatePropertyRequest
 import uvg.edu.tripwise.network.RetrofitInstance
+import java.lang.IllegalStateException
 
 class PropertyRepository {
 
     private val api = RetrofitInstance.api
 
-    // --- Mapper a dominio (re-usa en todos los métodos) ---
     private fun ApiProperty.toDomain(): Property = Property(
         id = _id,
         name = name,
@@ -32,7 +34,6 @@ class PropertyRepository {
         )
     )
 
-    // ---------------------- READ ----------------------
     suspend fun getProperties(): List<Property> =
         api.getProperties().map { it.toDomain() }
 
@@ -42,7 +43,6 @@ class PropertyRepository {
     suspend fun getPropertyById(id: String): Property =
         api.getPropertyById(id).toDomain()
 
-    // ---------------------- CREATE ----------------------
     suspend fun createProperty(
         ownerId: String,
         name: String,
@@ -78,7 +78,6 @@ class PropertyRepository {
         return resp.body()!!.toDomain()
     }
 
-    // ---------------------- DELETE ----------------------
     suspend fun deleteProperty(id: String): Boolean =
         try {
             val resp = api.deleteProperty(id)
@@ -88,4 +87,12 @@ class PropertyRepository {
         }
 
 
+    suspend fun updateProperty(id: String, request: UpdatePropertyRequest): Property {
+        // Asumiendo que esta llamada existe en tu interfaz Retrofit 'api'
+        val resp = api.updateProperty(id, request)
+        if (!resp.isSuccessful || resp.body() == null) {
+            throw IllegalStateException("No se pudo actualizar la propiedad (${resp.code()})")
+        }
+        return resp.body()!!.toDomain()
+    }
 }

--- a/app/src/main/java/uvg/edu/tripwise/network/ApiService.kt
+++ b/app/src/main/java/uvg/edu/tripwise/network/ApiService.kt
@@ -252,6 +252,11 @@ interface UserApiService {
     suspend fun getItinerariesByUser(@Path("userId") userId: String): List<ItineraryResponse>
 }
 
+/**
+ * ESTA INTERFAZ ES LA QUE HABÍA BORRADO.
+ * La volvemos a agregar para que RetrofitInstance.PropertyApi funcione
+ * y tus ReservationPage dejen de dar error.
+ */
 interface PropertyApiService {
     @GET("property")
     suspend fun getProperties(): List<Property>
@@ -268,3 +273,4 @@ interface PropertyApiService {
     @DELETE("property/{id}")
     suspend fun deleteProperty(@Path("id") id: String): Response<Unit>
 }
+

--- a/app/src/main/java/uvg/edu/tripwise/network/RetrofitInstance.kt
+++ b/app/src/main/java/uvg/edu/tripwise/network/RetrofitInstance.kt
@@ -19,6 +19,10 @@ object RetrofitInstance {
         .addInterceptor(loggingInterceptor)
         .build()
 
+    /**
+     * Instancia principal que usa UserApiService.
+     * Usada por los nuevos repositorios y pantallas de Admin.
+     */
     val api: UserApiService by lazy {
         Retrofit.Builder()
             .baseUrl(BASE_URL)
@@ -28,6 +32,11 @@ object RetrofitInstance {
             .create(UserApiService::class.java)
     }
 
+    /**
+     * (DEVUELTA)
+     * Instancia que usa PropertyApiService.
+     * Requerida por tus archivos ReservationPage.
+     */
     val PropertyApi: PropertyApiService by lazy {
         Retrofit.Builder()
             .baseUrl(BASE_URL)

--- a/app/src/main/java/uvg/edu/tripwise/viewModel/ProfileViewModel.kt
+++ b/app/src/main/java/uvg/edu/tripwise/viewModel/ProfileViewModel.kt
@@ -134,13 +134,18 @@ class ProfileViewModel(application: Application) : AndroidViewModel(application)
                 // Ya tenemos la URL de la imagen (nueva o la antigua)
 
                 // --- PASO 3: Actualizar Datos del Usuario ---
+
+                // --- ¡¡AQUÍ ESTÁ LA CORRECCIÓN!! ---
+                // Añadimos el parámetro 'role', pasando el rol actual del usuario.
                 val updatedUser = userRepository.updateUser(
                     id = currentUserId,
                     name = name,
                     email = email,
                     pfp = newPfpUrl, // Usa la URL que obtuvimos
+                    role = uiState.value.user?.role, // <-- PARÁMETRO AÑADIDO
                     interests = interests
                 )
+                // --- FIN DE LA CORRECCIÓN ---
 
                 // --- PASO 4: Éxito Total ---
                 _uiState.update {


### PR DESCRIPTION
This commit refactors the admin detail screens for both users and properties, introducing several key improvements:

-   **feat(admin):** Implemented editable fields on the User and Property detail screens, allowing administrators to modify data directly.
-   **feat(admin):** Replaced static text fields for 'role', 'propertyType', and 'approved' status with a new reusable `EnumDropdownSelector` composable, ensuring valid data entry.
-   **fix(api):** Corrected the `updateUser` method in `UserRepository` and `ProfileViewModel` to include the `role` parameter, preventing accidental nullification of user roles during profile updates.
-   **refactor(admin):** Created `CommonComposables.kt` to house shared UI components like `InfoRow` and the new `EnumDropdownSelector`, improving code reuse.
-   **fix(network):** Reinstated the `PropertyApiService` interface and its corresponding `PropertyApi` instance in `RetrofitInstance` to resolve compilation errors in reservation-related files.

## Type of Change
- [ ] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 📝 Documentation update
- [x] ♻️ Refactor
- [ ] ⚙️ Chore

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist
- [x] My code follows the project’s coding standards
- [ ] I have added tests to prove my fix/feature works
- [x] I have updated documentation if needed
- [x] No new warnings or errors were introduced
