### PR TITLE
host: properties host tabs + global pull-to-refresh; wire Bookings/Re…

### DIFF
--- a/.idea/caches/deviceStreaming.xml
+++ b/.idea/caches/deviceStreaming.xml
@@ -101,6 +101,18 @@
           <option name="screenY" value="1920" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a06" />
+          <option name="id" value="a06" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A06" />
+          <option name="screenDensity" value="300" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="a14m" />
@@ -180,6 +192,18 @@
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="SM-A366E" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a56x" />
+          <option name="id" value="a56x" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-A566E" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -341,6 +365,18 @@
           <option name="screenDensity" value="420" />
           <option name="screenX" value="2220" />
           <option name="screenY" value="1080" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="dm1q" />
+          <option name="id" value="dm1q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="S23" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />
@@ -764,6 +800,18 @@
           <option name="screenDensity" value="420" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="psq" />
+          <option name="id" value="psq" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S25 Edge" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3120" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
           <option name="api" value="34" />

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -5,6 +5,9 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="PropertiesHostPreview (1)">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/.kotlin/errors/errors-1762459321990.log
+++ b/.kotlin/errors/errors-1762459321990.log
@@ -1,0 +1,4 @@
+kotlin version: 2.0.21
+error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
+    1. Kotlin compile daemon is ready
+

--- a/.kotlin/errors/errors-1762470003150.log
+++ b/.kotlin/errors/errors-1762470003150.log
@@ -1,0 +1,4 @@
+kotlin version: 2.0.21
+error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
+    1. Kotlin compile daemon is ready
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
     implementation(libs.androidx.tv.material)
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.ui.text)
+    implementation(libs.foundation)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -122,9 +122,6 @@
             android:name=".profile.ProfileActivity"
             android:exported="false" />
         <activity
-            android:name=".profile.ChangePasswordActivity"
-            android:exported="false" />
-        <activity
             android:name=".host.ProfileHostActivity"
             android:exported="false" />
 

--- a/app/src/main/java/uvg/edu/tripwise/data/model/ReviewsDomainModels.kt
+++ b/app/src/main/java/uvg/edu/tripwise/data/model/ReviewsDomainModels.kt
@@ -1,0 +1,21 @@
+package uvg.edu.tripwise.data.model
+
+data class PropertyReviews(
+    val propertyId: String,
+    val propertyName: String,
+    val totalReviews: Int,
+    val averageScore: Double,
+    val scoreDistribution: Map<Int, Int>,
+    val reviews: List<ReviewItem>
+)
+
+data class ReviewItem(
+    val id: String,
+    val userName: String,
+    val userAvatar: String?,
+    val score: Int,
+    val date: String,
+    val likes: Int,
+    val commentsCount: Int,
+    val commentText: String?    // <- NUEVO
+)

--- a/app/src/main/java/uvg/edu/tripwise/data/repository/AvailabilityRepository.kt
+++ b/app/src/main/java/uvg/edu/tripwise/data/repository/AvailabilityRepository.kt
@@ -1,0 +1,17 @@
+package uvg.edu.tripwise.data.repository
+
+import uvg.edu.tripwise.network.RetrofitInstance
+import uvg.edu.tripwise.network.UserApiService
+
+class AvailabilityRepository(
+    private val api: UserApiService = RetrofitInstance.api
+) {
+    /**
+     * Devuelve las fechas ocupadas como Strings "YYYY-MM-DD" (idénticas a la API).
+     * Sin java.time para evitar requisitos de API 26.
+     */
+    suspend fun getUnavailableDates(propertyId: String): Set<String> {
+        val resp = api.getAvailability(propertyId)
+        return resp.unavailableDates.toSet()
+    }
+}

--- a/app/src/main/java/uvg/edu/tripwise/data/repository/PropertyRepository.kt
+++ b/app/src/main/java/uvg/edu/tripwise/data/repository/PropertyRepository.kt
@@ -2,15 +2,19 @@ package uvg.edu.tripwise.data.repository
 
 import uvg.edu.tripwise.data.model.Deleted
 import uvg.edu.tripwise.data.model.Property
+import uvg.edu.tripwise.data.model.PropertyReviews
+import uvg.edu.tripwise.data.model.ReviewItem
 import uvg.edu.tripwise.network.ApiProperty
+import uvg.edu.tripwise.network.ApiReviewsResponse
 import uvg.edu.tripwise.network.CreatePropertyRequest
 import uvg.edu.tripwise.network.RetrofitInstance
+import retrofit2.Response
 
 class PropertyRepository {
 
     private val api = RetrofitInstance.api
 
-    // --- Mapper a dominio (re-usa en todos los métodos) ---
+    // Mapper común → dominio
     private fun ApiProperty.toDomain(): Property = Property(
         id = _id,
         name = name,
@@ -23,16 +27,16 @@ class PropertyRepository {
         propertyType = propertyType,
         owner = owner,
         approved = approved,
-        latitude = latitude ?: 0.0,   // null-safe por datos faltantes
-        longitude = longitude ?: 0.0, // null-safe por datos faltantes
+        latitude = latitude ?: 0.0,
+        longitude = longitude ?: 0.0,
         createdAt = createdAt,
         deleted = Deleted(
-            isDeleted = deleted.`is`, // backticks por key "is"
+            isDeleted = deleted.`is`,
             at = deleted.at
         )
     )
 
-    // ---------------------- READ ----------------------
+    // READ
     suspend fun getProperties(): List<Property> =
         api.getProperties().map { it.toDomain() }
 
@@ -42,7 +46,7 @@ class PropertyRepository {
     suspend fun getPropertyById(id: String): Property =
         api.getPropertyById(id).toDomain()
 
-    // ---------------------- CREATE ----------------------
+    // CREATE
     suspend fun createProperty(
         ownerId: String,
         name: String,
@@ -78,7 +82,7 @@ class PropertyRepository {
         return resp.body()!!.toDomain()
     }
 
-    // ---------------------- DELETE ----------------------
+    // DELETE
     suspend fun deleteProperty(id: String): Boolean =
         try {
             val resp = api.deleteProperty(id)
@@ -87,5 +91,43 @@ class PropertyRepository {
             false
         }
 
+    // REVIEWS
+    suspend fun getReviewsByProperty(propertyId: String): PropertyReviews {
+        val resp: Response<ApiReviewsResponse> = api.getReviewsByProperty(propertyId)
+        if (!resp.isSuccessful || resp.body() == null) {
+            throw IllegalStateException("No se pudieron cargar reseñas (${resp.code()})")
+        }
+        val response = resp.body()!!
+
+        // Map<String,Int> → Map<Int,Int> a prueba de basura
+        val converted = mutableMapOf<Int, Int>()
+        response.statistics.scoreDistribution.forEach { (k, v) ->
+            k.toIntOrNull()?.let { converted[it] = v }
+        }
+        // Garantiza claves 1..5 presentes
+        for (s in 1..5) if (s !in converted) converted[s] = 0
+
+        return PropertyReviews(
+            propertyId = response.property.id,
+            propertyName = response.property.name,
+            totalReviews = response.statistics.totalReviews,
+            averageScore = response.statistics.averageScore,
+            scoreDistribution = converted.toSortedMap(compareByDescending { it }),
+            reviews = response.reviews.mapIndexed { idx, it ->
+                val firstCommentText = it.comments.firstOrNull()?.comment
+                ReviewItem(
+                    id = it.reviewId.ifBlank { "${response.property.id}_$idx" },
+                    userName = it.user.name,
+                    userAvatar = it.user.profilePicture,
+                    score = it.score,
+                    date = it.date,
+                    likes = it.likes,
+                    commentsCount = it.commentsCount,
+                    commentText = firstCommentText  // <- NUEVO
+                )
+            }
+
+        )
+    }
 
 }

--- a/app/src/main/java/uvg/edu/tripwise/data/repository/ReservationRepository.kt
+++ b/app/src/main/java/uvg/edu/tripwise/data/repository/ReservationRepository.kt
@@ -1,0 +1,78 @@
+package uvg.edu.tripwise.data.repository
+
+import uvg.edu.tripwise.network.ApiProperty
+import uvg.edu.tripwise.network.ApiUser
+import uvg.edu.tripwise.network.RetrofitInstance
+import uvg.edu.tripwise.network.ReservationResponse
+import uvg.edu.tripwise.network.UpdateReservationRequest
+import uvg.edu.tripwise.network.PropertyDeleted
+
+/**
+ * Repositorio para reservas del host.
+ * Envuelve los endpoints existentes del ApiService.
+ */
+class ReservationRepository {
+    private val api = RetrofitInstance.api
+
+    /**
+     * Lista reservas por propiedad (host).
+     * Convierte la respuesta del API al formato ReservationResponse.
+     */
+    suspend fun getByProperty(propertyId: String): List<ReservationResponse> {
+        val response = api.getReservationsProperty(propertyId)
+
+        // Convertir ReservationItem a ReservationResponse
+        return response.reservations.map { item ->
+            ReservationResponse(
+                id = item.reservationId,
+                reservationUser = ApiUser(
+                    id = item.user.id,
+                    name = item.user.name,
+                    email = item.user.email,
+                    pfp = null,
+                    role = null,
+                    properties = null,
+                    bookings = null,
+                    itineraries = null,
+                    moneyProperty = null,
+                    moneyItinerary = null,
+                    interests = null,
+                    createdAt = item.reservationDate,
+                    deleted = null
+                ),
+                propertyBooked = ApiProperty(
+                    _id = response.property.id,
+                    name = response.property.name,
+                    description = "",
+                    location = "",
+                    pricePerNight = 0.0,
+                    capacity = 0,
+                    pictures = emptyList(),
+                    amenities = emptyList(),
+                    propertyType = "",
+                    owner = "",
+                    approved = "",
+                    latitude = null,
+                    longitude = null,
+                    createdAt = "",
+                    deleted = PropertyDeleted(`is` = false, at = null),
+                    reviews = null
+                ),
+                checkInDate = item.checkInDate,
+                checkOutDate = item.checkOutDate,
+                payment = item.payment,
+                state = item.state,
+                persons = item.persons,
+                days = item.days,
+                itinerary = null
+            )
+        }
+    }
+
+    /** Actualiza sólo el estado (opcional para futuras acciones). */
+    suspend fun updateState(id: String, state: String): ReservationResponse? =
+        api.updateReservation(id, UpdateReservationRequest(state = state)).body()
+
+}
+
+

--- a/app/src/main/java/uvg/edu/tripwise/host/Bookings.kt
+++ b/app/src/main/java/uvg/edu/tripwise/host/Bookings.kt
@@ -1,0 +1,295 @@
+package uvg.edu.tripwise.host
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import uvg.edu.tripwise.data.repository.ReservationRepository
+import uvg.edu.tripwise.network.ReservationResponse
+import java.text.NumberFormat
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+private val PrimaryBlue  = Color(0xFF2563EB)
+private val SuccessGreen = Color(0xFF0AA12E)
+private val DangerRed    = Color(0xFFE2265B)
+
+/**
+ * Sección de reservas dentro del Host.
+ * SIN LazyColumn. El scroll lo lleva el contenedor padre (PropertiesHost).
+ */
+@Composable
+fun ReservationsSection(
+    propertyId: String,
+    reloadKey: Int = 0
+) {
+    val repo = remember { ReservationRepository() }
+
+    var isLoading by remember { mutableStateOf(false) }
+    var error     by remember { mutableStateOf<String?>(null) }
+    var items     by remember { mutableStateOf<List<ReservationResponse>>(emptyList()) }
+    var selectedIndex by remember { mutableStateOf(-1) }
+
+    // Recarga automática por cambio de propiedad o reload global
+    val currentPropertyId by rememberUpdatedState(propertyId)
+    LaunchedEffect(currentPropertyId, reloadKey) {
+        isLoading = true
+        error = null
+        try {
+            items = repo.getByProperty(currentPropertyId)
+        } catch (e: Exception) {
+            error = e.message
+        } finally {
+            isLoading = false
+        }
+    }
+
+    val reservations = remember(items) {
+        items.sortedWith(compareBy { toDateSafe(it.checkInDate) ?: Date(Long.MAX_VALUE) })
+    }
+    val activeCount = reservations.count { it.state.equals("confirmed", ignoreCase = true) }
+
+    // Sin scroll interno: el padre (PropertiesHost) ya es verticalScroll
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "Your bookings",
+                color = PrimaryBlue,
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Bold
+            )
+            PillTag(text = "$activeCount active", color = SuccessGreen)
+        }
+        Spacer(Modifier.height(14.dp))
+
+        when {
+            isLoading -> LoadingCard()
+            error != null -> ErrorCard(error!!)
+            reservations.isEmpty() -> EmptyCard("No bookings yet")
+            else -> {
+                reservations.forEachIndexed { index, r ->
+                    ReservationItemBound(
+                        name      = resolveGuestName(r),
+                        dateRange = formatRange(r.checkInDate, r.checkOutDate),
+                        amount    = formatMoney(r.payment),
+                        state     = r.state,
+                        persons   = r.persons,
+                        selected  = index == selectedIndex,
+                        onClick   = { selectedIndex = index }
+                    )
+                }
+            }
+        }
+    }
+}
+
+/* =========================
+   Components
+   ========================= */
+
+@Composable
+private fun PillTag(text: String, color: Color) {
+    Surface(
+        color = color,
+        contentColor = Color.White,
+        shape = RoundedCornerShape(50),
+        shadowElevation = 0.dp
+    ) {
+        Text(
+            text,
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 6.dp),
+            fontWeight = FontWeight.SemiBold
+        )
+    }
+}
+
+@Composable
+private fun ReservationItemBound(
+    name: String,
+    dateRange: String,
+    amount: String,
+    state: String,
+    persons: Int,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    val border = if (selected) BorderStroke(2.dp, PrimaryBlue)
+    else BorderStroke(1.dp, Color(0xFFE8E8F0))
+
+    val (statusColor, statusText) = when (state.lowercase(Locale.US)) {
+        "confirmed" -> SuccessGreen to "Confirmed"
+        "pending"   -> DangerRed    to "Pending"
+        "cancelled" -> Color(0xFF9CA3AF) to "Cancelled"
+        else        -> Color(0xFF9CA3AF) to state
+    }
+
+    Card(
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        border = border,
+        elevation = CardDefaults.cardElevation(0.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+    ) {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            androidx.compose.foundation.layout.Column(Modifier.weight(1f)) {
+                Text(
+                    name,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color(0xFF102A43)
+                )
+                Spacer(Modifier.height(4.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(dateRange, color = Color(0xFF6B7A90))
+                    Spacer(Modifier.size(8.dp))
+                    androidx.compose.material3.Icon(
+                        Icons.Filled.People,
+                        contentDescription = null,
+                        tint = Color(0xFF6B7A90)
+                    )
+                    Text(" $persons", color = Color(0xFF6B7A90))
+                }
+            }
+            androidx.compose.foundation.layout.Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    amount,
+                    color = SuccessGreen,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(Modifier.height(8.dp))
+                StatusChip(text = statusText, color = statusColor)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusChip(text: String, color: Color) {
+    Surface(
+        color = color,
+        contentColor = Color.White,
+        shape = RoundedCornerShape(50),
+        shadowElevation = 0.dp
+    ) {
+        Text(
+            text,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            fontWeight = FontWeight.SemiBold
+        )
+    }
+}
+
+@Composable private fun LoadingCard() = PlaceholderCard("Loading…")
+@Composable private fun EmptyCard(text: String) = PlaceholderCard(text)
+@Composable private fun ErrorCard(message: String) = PlaceholderCard("Error: $message")
+
+@Composable
+private fun PlaceholderCard(text: String) {
+    Card(
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(0.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text, color = Color(0xFF50607A), style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+/* =========================
+   Helpers
+   ========================= */
+
+private fun resolveGuestName(r: ReservationResponse): String {
+    return try {
+        if (r.reservationUser is uvg.edu.tripwise.network.ApiUser) {
+            r.reservationUser.name
+        } else {
+            @Suppress("UNCHECKED_CAST")
+            (r.reservationUser as? Map<*, *>)?.get("name") as? String ?: "Guest"
+        }
+    } catch (_: Throwable) {
+        "Guest"
+    }
+}
+
+private fun toDateSafe(raw: String?): Date? {
+    if (raw.isNullOrBlank()) return null
+    raw.toLongOrNull()?.let { ms ->
+        val minMs = 946684800000L // 2000-01-01
+        return if (ms >= minMs) Date(ms) else null
+    }
+    val utc = TimeZone.getTimeZone("UTC")
+    val f1 = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply { timeZone = utc }
+    val f2 = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'",       Locale.US).apply { timeZone = utc }
+    return try { f1.parse(raw) } catch (_: ParseException) { try { f2.parse(raw) } catch (_: ParseException) { null } }
+}
+
+private fun formatRange(ci: String?, co: String?): String {
+    val d1 = toDateSafe(ci) ?: return "—"
+    val d2 = toDateSafe(co) ?: return "—"
+    val mon = SimpleDateFormat("MMM", Locale.ENGLISH)
+    val day = SimpleDateFormat("d", Locale.US)
+    val m1 = mon.format(d1); val m2 = mon.format(d2)
+    val a1 = day.format(d1); val a2 = day.format(d2)
+    return if (m1 == m2) "$m1 $a1–$a2" else "$m1 $a1 – $m2 $a2"
+}
+
+private fun formatMoney(value: Any?): String {
+    val v = (value as? Number)?.toDouble() ?: 0.0
+    return NumberFormat.getCurrencyInstance(Locale.US).format(v)
+}

--- a/app/src/main/java/uvg/edu/tripwise/host/Calendar.kt
+++ b/app/src/main/java/uvg/edu/tripwise/host/Calendar.kt
@@ -1,0 +1,191 @@
+package uvg.edu.tripwise.host
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import uvg.edu.tripwise.data.repository.AvailabilityRepository
+import java.text.DateFormatSymbols
+import java.util.Calendar
+import java.util.Locale
+
+@Composable
+fun CalendarSection(
+    propertyId: String,
+    reloadKey: Int, // ✅ para recarga vía pull-to-refresh global
+    modifier: Modifier = Modifier,
+    vm: CalendarViewModel = viewModel(
+        factory = CalendarViewModelFactory(AvailabilityRepository())
+    )
+) {
+    // recarga al entrar / cambiar propiedad / refrescar manual
+    LaunchedEffect(propertyId, reloadKey) { vm.loadAvailability(propertyId) }
+
+    val state by vm.state.collectAsState()
+
+    // Estado del mes actual sin java.time
+    var year by remember { mutableStateOf(Calendar.getInstance().get(Calendar.YEAR)) }
+    var monthZero by remember { mutableStateOf(Calendar.getInstance().get(Calendar.MONTH)) }
+
+    Column(modifier = modifier.padding(16.dp)) {
+
+        // Header con navegación de mes
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            TextButton(onClick = {
+                if (monthZero == 0) { monthZero = 11; year -= 1 } else { monthZero -= 1 }
+            }) { Text("◀") }
+
+            Text(
+                text = monthTitle(year, monthZero),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            TextButton(onClick = {
+                if (monthZero == 11) { monthZero = 0; year += 1 } else { monthZero += 1 }
+            }) { Text("▶") }
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        when {
+            state.loading -> LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            state.error != null -> Text(
+                text = state.error ?: "Error",
+                color = MaterialTheme.colorScheme.error
+            )
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        MonthGrid(
+            year = year,
+            monthZero = monthZero,
+            unavailable = state.unavailable
+        )
+    }
+}
+
+private fun monthTitle(year: Int, monthZero: Int): String {
+    val months = DateFormatSymbols(Locale.getDefault()).months
+    val name = months[monthZero].replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+    return "$name $year"
+}
+
+@Composable
+private fun MonthGrid(
+    year: Int,
+    monthZero: Int,
+    unavailable: Set<String> // "YYYY-MM-DD"
+) {
+    val cal = Calendar.getInstance().apply {
+        set(Calendar.YEAR, year)
+        set(Calendar.MONTH, monthZero)
+        set(Calendar.DAY_OF_MONTH, 1)
+        set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+    }
+
+    val dayOfWeek = cal.get(Calendar.DAY_OF_WEEK) // 1=Dom ... 7=Sáb
+    val firstDayOfWeek = Calendar.MONDAY
+    val leadingEmpty = ((dayOfWeek - firstDayOfWeek + 7) % 7)
+    val daysInMonth = cal.getActualMaximum(Calendar.DAY_OF_MONTH)
+
+    val cells: List<Int?> = buildList {
+        repeat(leadingEmpty) { add(null) }
+        for (d in 1..daysInMonth) add(d)
+        while (size % 7 != 0) add(null)
+    }
+
+    // Encabezado
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        val order = listOf(
+            Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY,
+            Calendar.THURSDAY, Calendar.FRIDAY, Calendar.SATURDAY, Calendar.SUNDAY
+        )
+        val short = DateFormatSymbols(Locale.getDefault()).shortWeekdays
+        for (wd in order) {
+            Text(
+                text = short[wd],
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+
+    Spacer(Modifier.height(6.dp))
+
+    // ⛔️ Sin LazyColumn (scroll lo hace el padre)
+    val rows = remember(cells) { cells.chunked(7) }
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        rows.forEach { row ->
+            Row(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                row.forEach { dayOrNull ->
+                    DayCell(
+                        year = year,
+                        monthZero = monthZero,
+                        day = dayOrNull,
+                        isUnavailable = dayOrNull?.let { d ->
+                            val key = dateKey(year, monthZero, d)
+                            unavailable.contains(key)
+                        } ?: false
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun dateKey(year: Int, monthZero: Int, day: Int): String =
+    String.format("%04d-%02d-%02d", year, monthZero + 1, day)
+
+@Composable
+private fun RowScope.DayCell(
+    year: Int,
+    monthZero: Int,
+    day: Int?,
+    isUnavailable: Boolean
+) {
+    val base = Modifier
+        .weight(1f)
+        .aspectRatio(1f)
+
+    if (day == null) {
+        Box(base)
+        return
+    }
+
+    val bg = if (isUnavailable) Color(0xFFFFE5E5) else Color.Transparent
+    val fg = if (isUnavailable) Color(0xFFD32F2F) else MaterialTheme.colorScheme.onSurface
+
+    Surface(
+        modifier = base,
+        shape = RoundedCornerShape(10.dp),
+        tonalElevation = if (isUnavailable) 1.dp else 0.dp,
+        color = bg
+    ) {
+        Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+            Text(
+                text = "%02d".format(day),
+                color = fg,
+                fontWeight = if (isUnavailable) FontWeight.Bold else FontWeight.Normal
+            )
+        }
+    }
+}

--- a/app/src/main/java/uvg/edu/tripwise/host/CalendarViewModel.kt
+++ b/app/src/main/java/uvg/edu/tripwise/host/CalendarViewModel.kt
@@ -1,0 +1,31 @@
+package uvg.edu.tripwise.host
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import uvg.edu.tripwise.data.repository.AvailabilityRepository
+
+data class CalendarUiState(
+    val loading: Boolean = false,
+    val unavailable: Set<String> = emptySet(), // "YYYY-MM-DD"
+    val error: String? = null
+)
+
+class CalendarViewModel(
+    private val repo: AvailabilityRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(CalendarUiState())
+    val state: StateFlow<CalendarUiState> = _state
+
+    fun loadAvailability(propertyId: String) {
+        _state.value = _state.value.copy(loading = true, error = null)
+        viewModelScope.launch {
+            runCatching { repo.getUnavailableDates(propertyId) }
+                .onSuccess { dates -> _state.value = CalendarUiState(false, dates, null) }
+                .onFailure { e -> _state.value = CalendarUiState(false, emptySet(), e.message ?: "Error") }
+        }
+    }
+}

--- a/app/src/main/java/uvg/edu/tripwise/host/CalendarViewModelFactory.kt
+++ b/app/src/main/java/uvg/edu/tripwise/host/CalendarViewModelFactory.kt
@@ -1,0 +1,14 @@
+package uvg.edu.tripwise.host
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import uvg.edu.tripwise.data.repository.AvailabilityRepository
+
+class CalendarViewModelFactory(
+    private val repo: AvailabilityRepository
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return CalendarViewModel(repo) as T
+    }
+}

--- a/app/src/main/java/uvg/edu/tripwise/host/CreatePropertyActivity.kt
+++ b/app/src/main/java/uvg/edu/tripwise/host/CreatePropertyActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
@@ -12,13 +13,13 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.*
@@ -110,7 +111,8 @@ fun CreatePropertyScreen(
     val propertyTypes = listOf(
         PType("house", stringResource(R.string.type_house), Icons.Filled.Home),
         PType("apartment", stringResource(R.string.type_apartment), Icons.Filled.Apartment),
-        PType("cabin", stringResource(R.string.type_cabin), Icons.Filled.HolidayVillage),
+        // 👇 Cambiado: antes "cabin", ahora el backend espera "cottage"
+        PType("cottage", stringResource(R.string.type_cabin), Icons.Filled.HolidayVillage),
         PType("hotel", stringResource(R.string.type_hotel), Icons.Filled.Hotel)
     )
     var selectedType by remember { mutableStateOf<PType?>(null) }
@@ -152,7 +154,13 @@ fun CreatePropertyScreen(
                     modifier = Modifier
                         .padding(start = 8.dp, top = 8.dp)
                         .align(Alignment.TopStart)
-                ) { Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.cd_back), tint = BrandBlue) }
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.cd_back),
+                        tint = BrandBlue
+                    )
+                }
             }
         }
     ) { inner ->
@@ -165,15 +173,35 @@ fun CreatePropertyScreen(
                 .verticalScroll(rememberScrollState())
         ) {
             Spacer(Modifier.height(12.dp))
-            Text(stringResource(R.string.title_new_property), fontSize = 24.sp, fontWeight = FontWeight.Bold, color = BrandBlue)
+            Text(
+                stringResource(R.string.title_new_property),
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                color = BrandBlue
+            )
             Spacer(Modifier.height(12.dp))
 
-            // ====== Inputs con focus styling ======
-            StyledTextField(value = name, onValueChange = { name = it }, label = stringResource(R.string.label_property_name), singleLine = true)
+            // ====== Inputs ======
+            StyledTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = stringResource(R.string.label_property_name),
+                singleLine = true
+            )
             Spacer(Modifier.height(12.dp))
-            StyledTextField(value = description, onValueChange = { description = it }, label = stringResource(R.string.label_description), minHeight = 120.dp)
+            StyledTextField(
+                value = description,
+                onValueChange = { description = it },
+                label = stringResource(R.string.label_description),
+                minHeight = 120.dp
+            )
             Spacer(Modifier.height(12.dp))
-            StyledTextField(value = location, onValueChange = { location = it }, label = stringResource(R.string.label_location), singleLine = true)
+            StyledTextField(
+                value = location,
+                onValueChange = { location = it },
+                label = stringResource(R.string.label_location),
+                singleLine = true
+            )
             Spacer(Modifier.height(12.dp))
 
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
@@ -199,7 +227,7 @@ fun CreatePropertyScreen(
             Text(stringResource(R.string.property_type_title), fontWeight = FontWeight.SemiBold)
             Spacer(Modifier.height(10.dp))
 
-            // ====== DESLIZABLE ======  -> evita que se aplasten cuando ensanchas el ícono
+            // ====== Tipos ======
             LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp), contentPadding = PaddingValues(horizontal = 2.dp)) {
                 items(propertyTypes) { type ->
                     val selected = selectedType?.key == type.key
@@ -237,13 +265,34 @@ fun CreatePropertyScreen(
                         latitude = latLng.latitude
                         longitude = latLng.longitude
                     }
-                ) { marker?.let { pos -> Marker(state = MarkerState(position = pos), title = stringResource(R.string.map_marker_selected)) } }
+                ) {
+                    marker?.let { pos ->
+                        Marker(
+                            state = MarkerState(position = pos),
+                            title = stringResource(R.string.map_marker_selected)
+                        )
+                    }
+                }
             }
 
             Spacer(Modifier.height(12.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
-                StyledTextField(value = latitude?.toString().orEmpty(), onValueChange = { latitude = it.toDoubleOrNull() }, label = stringResource(R.string.label_latitude), keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal), singleLine = true, modifier = Modifier.weight(1f))
-                StyledTextField(value = longitude?.toString().orEmpty(), onValueChange = { longitude = it.toDoubleOrNull() }, label = stringResource(R.string.label_longitude), keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal), singleLine = true, modifier = Modifier.weight(1f))
+                StyledTextField(
+                    value = latitude?.toString().orEmpty(),
+                    onValueChange = { latitude = it.toDoubleOrNull() },
+                    label = stringResource(R.string.label_latitude),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    singleLine = true,
+                    modifier = Modifier.weight(1f)
+                )
+                StyledTextField(
+                    value = longitude?.toString().orEmpty(),
+                    onValueChange = { longitude = it.toDoubleOrNull() },
+                    label = stringResource(R.string.label_longitude),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    singleLine = true,
+                    modifier = Modifier.weight(1f)
+                )
             }
 
             Spacer(Modifier.height(18.dp))
@@ -259,7 +308,13 @@ fun CreatePropertyScreen(
                                 label = amenity.name,
                                 icon = amenity.icon,
                                 selected = sel,
-                                onClick = { selectedAmenities = if (sel) selectedAmenities - amenity.name else selectedAmenities + amenity.name },
+                                onClick = {
+                                    selectedAmenities = if (sel) {
+                                        selectedAmenities - amenity.name
+                                    } else {
+                                        selectedAmenities + amenity.name
+                                    }
+                                },
                                 height = AMENITY_CARD_HEIGHT,
                                 modifier = Modifier.weight(1f)
                             )
@@ -280,14 +335,26 @@ fun CreatePropertyScreen(
                         .size(44.dp)
                         .clip(CircleShape)
                         .clickable(enabled = !isSubmitting) { imagesPicker.launch("image/*") }
-                ) { Box(contentAlignment = Alignment.Center) { Icon(Icons.Filled.Image, contentDescription = stringResource(R.string.cd_add_images), tint = SelectedBlue) } }
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            Icons.Filled.Image,
+                            contentDescription = stringResource(R.string.cd_add_images),
+                            tint = SelectedBlue
+                        )
+                    }
+                }
                 Spacer(Modifier.width(10.dp))
-                val picsText = if (pictureUris.isEmpty()) stringResource(R.string.no_images_selected) else stringResource(R.string.images_selected_count, pictureUris.size)
+                val picsText =
+                    if (pictureUris.isEmpty()) stringResource(R.string.no_images_selected)
+                    else stringResource(R.string.images_selected_count, pictureUris.size)
                 Text(text = picsText, color = Color(0xFF475569))
             }
 
             Spacer(Modifier.height(24.dp))
-            errorMsg?.let { msg -> Text(msg, color = Color(0xFFDC2626), modifier = Modifier.padding(bottom = 12.dp)) }
+            errorMsg?.let { msg ->
+                Text(msg, color = Color(0xFFDC2626), modifier = Modifier.padding(bottom = 12.dp))
+            }
 
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 OutlinedButton(
@@ -297,17 +364,23 @@ fun CreatePropertyScreen(
                     shape = RoundedCornerShape(Corner),
                     colors = ButtonDefaults.outlinedButtonColors(contentColor = SelectedBlue),
                     border = BorderStroke(1.5.dp, SelectedBlue)
-                ) { Text(stringResource(R.string.action_cancel)) }
+                ) {
+                    Text(stringResource(R.string.action_cancel))
+                }
 
                 Button(
                     onClick = {
                         val priceVal = price.toDoubleOrNull()
                         val capVal = capacity.toIntOrNull()
                         when {
-                            name.isBlank() || description.isBlank() || location is String && location.isBlank() -> errorMsg = context.getString(R.string.error_fill_name_desc_location)
-                            priceVal == null || capVal == null -> errorMsg = context.getString(R.string.error_price_capacity_numeric)
-                            selectedType == null -> errorMsg = context.getString(R.string.error_select_property_type)
-                            latitude == null || longitude == null -> errorMsg = context.getString(R.string.error_valid_coordinates)
+                            name.isBlank() || description.isBlank() || location.isBlank() ->
+                                errorMsg = context.getString(R.string.error_fill_name_desc_location)
+                            priceVal == null || capVal == null ->
+                                errorMsg = context.getString(R.string.error_price_capacity_numeric)
+                            selectedType == null ->
+                                errorMsg = context.getString(R.string.error_select_property_type)
+                            latitude == null || longitude == null ->
+                                errorMsg = context.getString(R.string.error_valid_coordinates)
                             else -> {
                                 errorMsg = null
                                 scope.launch {
@@ -315,14 +388,28 @@ fun CreatePropertyScreen(
                                     try {
                                         val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
                                         val ownerId = prefs.getString("USER_ID", prefs.getString("user_id", null))
-                                        if (ownerId.isNullOrBlank()) { errorMsg = context.getString(R.string.error_no_user_session); isSubmitting = false; return@launch }
+                                        if (ownerId.isNullOrBlank()) {
+                                            errorMsg = context.getString(R.string.error_no_user_session)
+                                            isSubmitting = false
+                                            return@launch
+                                        }
+
+                                        // Mapear imágenes: enviar [] si no son URLs públicas todavía
+                                        val mapped = pictureUris.map { it.toString() }
+                                        val picturesField =
+                                            if (mapped.isNotEmpty() && mapped.all { it.startsWith("http://") || it.startsWith("https://") }) {
+                                                mapped
+                                            } else {
+                                                emptyList()
+                                            }
+
                                         val req = CreatePropertyRequest(
                                             name = name,
                                             description = description,
                                             location = location,
                                             pricePerNight = priceVal,
                                             capacity = capVal,
-                                            pictures = pictureUris.map { it.toString() },
+                                            pictures = picturesField,
                                             amenities = selectedAmenities.toList(),
                                             propertyType = selectedType!!.key,
                                             owner = ownerId,
@@ -330,9 +417,21 @@ fun CreatePropertyScreen(
                                             latitude = latitude!!,
                                             longitude = longitude!!
                                         )
+
                                         val resp = RetrofitInstance.api.createProperty(req)
-                                        if (resp.isSuccessful) onCreated() else errorMsg = context.getString(R.string.server_error_with_code, resp.code())
-                                    } catch (e: Exception) { errorMsg = e.message ?: context.getString(R.string.network_error) } finally { isSubmitting = false }
+                                        if (resp.isSuccessful) {
+                                            onCreated()
+                                        } else {
+                                            val body = resp.errorBody()?.string()
+                                            errorMsg = body ?: context.getString(R.string.server_error_with_code, resp.code())
+                                            Log.e("CreateProperty", "createProperty failed: code=${resp.code()} body=$body")
+                                        }
+                                    } catch (e: Exception) {
+                                        errorMsg = e.message ?: context.getString(R.string.network_error)
+                                        Log.e("CreateProperty", "exception on createProperty", e)
+                                    } finally {
+                                        isSubmitting = false
+                                    }
                                 }
                             }
                         }
@@ -341,7 +440,9 @@ fun CreatePropertyScreen(
                     enabled = !isSubmitting,
                     shape = RoundedCornerShape(Corner),
                     colors = ButtonDefaults.buttonColors(containerColor = SelectedBlue, contentColor = Color.White)
-                ) { Text(stringResource(R.string.action_add_property)) }
+                ) {
+                    Text(stringResource(R.string.action_add_property))
+                }
             }
 
             Spacer(Modifier.height(24.dp))
@@ -406,7 +507,10 @@ private fun TypeCard(
             modifier = Modifier.fillMaxSize()
         ) {
             Surface(shape = RoundedCornerShape(10.dp), color = if (selected) SelectedBlue else Color(0xFFF2F4F8)) {
-                Box(Modifier.size(width = TYPE_ICON_BOX_WIDTH, height = TYPE_ICON_BOX_HEIGHT), contentAlignment = Alignment.Center) {
+                Box(
+                    Modifier.size(width = TYPE_ICON_BOX_WIDTH, height = TYPE_ICON_BOX_HEIGHT),
+                    contentAlignment = Alignment.Center
+                ) {
                     Icon(icon, contentDescription = null, tint = if (selected) Color.White else Color(0xFF6B7280))
                 }
             }
@@ -441,11 +545,13 @@ private fun AmenityCard(
                 .fillMaxSize()
                 .padding(horizontal = 12.dp)
         ) {
-            Box(Modifier.size(width = AMENITY_ICON_BOX_WIDTH, height = AMENITY_ICON_BOX_HEIGHT), contentAlignment = Alignment.Center) {
+            Box(
+                Modifier.size(width = AMENITY_ICON_BOX_WIDTH, height = AMENITY_ICON_BOX_HEIGHT),
+                contentAlignment = Alignment.Center
+            ) {
                 Icon(icon, contentDescription = null, tint = if (selected) SelectedBlue else Color(0xFF6B7280))
             }
             Text(label, fontSize = AMENITY_TEXT_SIZE, color = if (selected) SelectedBlue else Color.Black)
         }
     }
-
 }

--- a/app/src/main/java/uvg/edu/tripwise/host/Overview.kt
+++ b/app/src/main/java/uvg/edu/tripwise/host/Overview.kt
@@ -1,0 +1,92 @@
+package uvg.edu.tripwise.host
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import uvg.edu.tripwise.R
+import uvg.edu.tripwise.data.model.Property
+import uvg.edu.tripwise.data.repository.PropertyRepository
+
+/* Colores locales (mismos valores visuales que en PropertiesHost.kt) */
+private val PrimaryBlue = Color(0xFF2563EB)
+private val SuccessGreen = Color(0xFF0AA12E)
+
+/** == Carga remota de la propiedad (igual contrato que antes) == */
+@Composable
+fun SummarySectionRemote(
+    propertyId: String?,
+    repo: PropertyRepository = PropertyRepository(),
+    reloadKey: Int = 0
+) {
+    var property by remember { mutableStateOf<Property?>(null) }
+    var loading by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(propertyId, reloadKey) {
+        val id = propertyId?.takeIf { it.isNotBlank() } ?: return@LaunchedEffect
+        try {
+            loading = true
+            property = repo.getPropertyById(id)
+        } catch (e: Exception) {
+            error = e.message
+        } finally {
+            loading = false
+        }
+    }
+
+    when {
+        propertyId.isNullOrBlank() -> PlaceholderSection(stringResource(R.string.select_property_to_see_overview))
+        loading -> PlaceholderSection(stringResource(R.string.loading_property))
+        error != null -> PlaceholderSection(stringResource(R.string.error_with_message, error ?: ""))
+        property == null -> PlaceholderSection(stringResource(R.string.property_not_found))
+        else -> SummarySectionBound(property = property!!)
+    }
+}
+
+/** == UI del Overview (usa helpers expuestos desde PropertiesHost.kt) == */
+@Composable
+fun SummarySectionBound(property: Property) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        WhiteCard(title = stringResource(R.string.basic_information)) {
+            KeyValueRow(stringResource(R.string.label_type), property.propertyType.ifBlank { stringResource(R.string.placeholder_em_dash) })
+            KeyValueRow(stringResource(R.string.label_guests), property.capacity.toString())
+            KeyValueRow(stringResource(R.string.label_rooms), stringResource(R.string.placeholder_em_dash))
+            KeyValueRow(stringResource(R.string.label_bathrooms), stringResource(R.string.placeholder_em_dash))
+
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(stringResource(R.string.label_price_per_night), fontWeight = FontWeight.SemiBold, color = Color(0xFF102A43))
+                Text("$${property.pricePerNight}", fontWeight = FontWeight.Bold, color = SuccessGreen)
+            }
+        }
+
+        WhiteCard(title = stringResource(R.string.amenities_title)) {
+            val amenities = property.amenities
+            if (amenities.isEmpty()) {
+                Text(stringResource(R.string.placeholder_em_dash), color = Color(0xFF26364D))
+            } else {
+                AmenitiesGrid(amenities)
+            }
+        }
+
+        Card(
+            shape = RoundedCornerShape(8.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            border = BorderStroke(2.dp, PrimaryBlue),
+            elevation = CardDefaults.cardElevation(0.dp)
+        ) {
+            Column(Modifier.padding(16.dp)) {
+                Text(stringResource(R.string.description_title), fontWeight = FontWeight.Bold, color = PrimaryBlue, fontSize = 18.sp)
+                Spacer(Modifier.height(8.dp))
+                Text(property.description.ifBlank { stringResource(R.string.placeholder_em_dash) }, color = Color(0xFF102A43), lineHeight = 20.sp)
+            }
+        }
+    }
+}

--- a/app/src/main/java/uvg/edu/tripwise/host/Reviews.kt
+++ b/app/src/main/java/uvg/edu/tripwise/host/Reviews.kt
@@ -1,0 +1,196 @@
+package uvg.edu.tripwise.host.reviews
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarOutline
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import uvg.edu.tripwise.data.model.PropertyReviews
+import uvg.edu.tripwise.data.model.ReviewItem
+
+private val PrimaryBlue = Color(0xFF2563EB)
+private val StarYellow = Color(0xFFFFB800)
+
+@Composable
+fun ReviewsSection(
+    propertyId: String,
+    viewModel: ReviewsViewModel,
+    reloadKey: Int
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(propertyId, reloadKey) {
+        viewModel.load(propertyId)
+    }
+
+    when {
+        state.loading -> {
+            Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = PrimaryBlue)
+            }
+        }
+        state.error != null -> {
+            Column(Modifier.fillMaxWidth().padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+                Text("Error: ${state.error}", color = Color(0xFFE2265B), style = MaterialTheme.typography.bodyMedium)
+                Spacer(Modifier.height(12.dp))
+                Button(onClick = { viewModel.load(propertyId) }, colors = ButtonDefaults.buttonColors(containerColor = PrimaryBlue)) {
+                    Text("Reintentar")
+                }
+            }
+        }
+        state.data != null -> ReviewsContent(state.data!!)
+    }
+}
+
+@Composable
+private fun ReviewsContent(data: PropertyReviews) {
+    // Sin LazyColumn. El scroll lo maneja el padre.
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "Reseñas de huéspedes",
+            color = PrimaryBlue,
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(Modifier.height(12.dp))
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(String.format("%.1f", data.averageScore), fontSize = 18.sp, fontWeight = FontWeight.SemiBold, color = Color(0xFF102A43))
+            Spacer(Modifier.width(4.dp))
+            Icon(Icons.Filled.Star, contentDescription = null, tint = StarYellow, modifier = Modifier.size(20.dp))
+            Spacer(Modifier.width(8.dp))
+            Text("· ${data.totalReviews} reviews", fontSize = 16.sp, color = Color(0xFF50607A))
+        }
+        Spacer(Modifier.height(12.dp))
+
+        ScoreDistributionBlock(dist = data.scoreDistribution)
+        Spacer(Modifier.height(12.dp))
+
+        Divider(thickness = 1.dp, color = PrimaryBlue.copy(alpha = 0.15f))
+        Spacer(Modifier.height(12.dp))
+
+        // Lista
+        data.reviews.forEachIndexed { idx, review ->
+            ReviewCard(review)
+            if (idx < data.reviews.lastIndex) Spacer(Modifier.height(12.dp))
+        }
+        Spacer(Modifier.height(12.dp))
+    }
+}
+
+@Composable
+private fun ScoreDistributionBlock(
+    dist: Map<Int, Int>,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        for (score in 5 downTo 1) {
+            val count = dist[score] ?: 0
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("$score", fontSize = 14.sp, color = Color(0xFF102A43), fontWeight = FontWeight.Medium)
+                Spacer(Modifier.width(4.dp))
+                Icon(Icons.Filled.Star, contentDescription = null, tint = StarYellow, modifier = Modifier.size(16.dp))
+                Spacer(Modifier.width(8.dp))
+                Text("· $count", fontSize = 14.sp, color = Color(0xFF50607A))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReviewCard(review: ReviewItem) {
+    Card(
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(2.dp),
+        border = BorderStroke(1.dp, Color(0xFFE8E8F0)),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(Modifier.fillMaxWidth().padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Top
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f)) {
+                    AsyncImage(model = review.userAvatar, contentDescription = null, modifier = Modifier.size(44.dp).clip(CircleShape))
+                    Spacer(Modifier.width(12.dp))
+                    Column {
+                        Text(review.userName, fontWeight = FontWeight.Bold, fontSize = 16.sp, color = Color(0xFF102A43))
+                        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(top = 4.dp)) {
+                            repeat(5) { i ->
+                                Icon(
+                                    imageVector = if (i < review.score) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                                    contentDescription = null,
+                                    tint = StarYellow,
+                                    modifier = Modifier.size(16.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+                Text(formatDate(review.date), fontSize = 12.sp, color = Color(0xFF50607A), modifier = Modifier.padding(start = 8.dp))
+            }
+
+            review.commentText?.let { text ->
+                Spacer(Modifier.height(10.dp))
+                Text(text = text, fontSize = 14.sp, color = Color(0xFF26364D), lineHeight = 20.sp)
+            }
+
+            if (review.commentsCount > 0) {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = "${review.commentsCount} comentario${if (review.commentsCount != 1) "s" else ""}",
+                    fontSize = 13.sp,
+                    color = PrimaryBlue,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+    }
+}
+
+/* =========================
+   Helpers
+   ========================= */
+
+private fun formatDate(dateString: String): String {
+    return try {
+        val parts = dateString.split("T")
+        if (parts.isNotEmpty()) {
+            val d = parts[0].split("-")
+            if (d.size == 3) {
+                val y = d[0].toInt(); val m = d[1].toInt(); val dd = d[2].toInt()
+                val days = calculateDaysAgo(y, m, dd)
+                when {
+                    days == 0 -> "Hoy"
+                    days == 1 -> "Hace 1 día"
+                    days < 7 -> "Hace $days días"
+                    days < 14 -> "Hace 1 semana"
+                    days < 30 -> "Hace ${days / 7} semanas"
+                    days < 60 -> "Hace 1 mes"
+                    else -> "Hace ${days / 30} meses"
+                }
+            } else dateString
+        } else dateString
+    } catch (_: Exception) { dateString }
+}
+
+private fun calculateDaysAgo(year: Int, month: Int, day: Int): Int {
+    val currentYear = 2025
+    val currentMonth = 11
+    val currentDay = 8
+    return maxOf(0, (currentYear - year) * 365 + (currentMonth - month) * 30 + (currentDay - day))
+}

--- a/app/src/main/java/uvg/edu/tripwise/host/ReviewsViewModel.kt
+++ b/app/src/main/java/uvg/edu/tripwise/host/ReviewsViewModel.kt
@@ -1,0 +1,50 @@
+package uvg.edu.tripwise.host.reviews
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import uvg.edu.tripwise.data.model.PropertyReviews
+import uvg.edu.tripwise.data.repository.PropertyRepository
+
+data class ReviewsUiState(
+    val loading: Boolean = false,
+    val data: PropertyReviews? = null,
+    val error: String? = null
+)
+
+class ReviewsViewModel(
+    private val repository: PropertyRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ReviewsUiState(loading = true))
+    val state: StateFlow<ReviewsUiState> = _state.asStateFlow()
+
+    fun load(propertyId: String) {
+        viewModelScope.launch {
+            _state.value = ReviewsUiState(loading = true)
+            try {
+                val reviews = repository.getReviewsByProperty(propertyId)
+                _state.value = ReviewsUiState(data = reviews)
+            } catch (e: Exception) {
+                _state.value = ReviewsUiState(error = e.message ?: "Error desconocido")
+            }
+        }
+    }
+
+    companion object {
+        fun provideFactory(repository: PropertyRepository): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    if (modelClass.isAssignableFrom(ReviewsViewModel::class.java)) {
+                        return ReviewsViewModel(repository) as T
+                    }
+                    throw IllegalArgumentException("Unknown ViewModel class")
+                }
+            }
+    }
+}

--- a/app/src/main/java/uvg/edu/tripwise/host/ReviewsViewModelFactory.kt
+++ b/app/src/main/java/uvg/edu/tripwise/host/ReviewsViewModelFactory.kt
@@ -1,0 +1,19 @@
+package uvg.edu.tripwise.host
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import uvg.edu.tripwise.data.repository.PropertyRepository
+import uvg.edu.tripwise.host.reviews.ReviewsViewModel
+
+class ReviewsViewModelFactory(
+    private val repository: PropertyRepository
+) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ReviewsViewModel::class.java)) {
+            return ReviewsViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -423,4 +423,6 @@
     <string name="status_pending">Pending</string>
     <string name="error_valid_coordinates">Enter valid coordinates.</string>
     <string name="cd_logout">Log out</string>
+
+    <string name ="ic_user_placeholder">Imagen</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ foundation = "1.9.0"
 tvMaterial = "1.0.1"
 foundationVersion = "1.9.1"
 uiText = "1.9.1"
+androidxFoundation = "1.9.4"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -32,6 +33,7 @@ androidx-foundation = { group = "androidx.compose.foundation", name = "foundatio
 androidx-tv-material = { group = "androidx.tv", name = "tv-material", version.ref = "tvMaterial" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundationVersion" }
 androidx-compose-ui-text = { group = "androidx.compose.ui", name = "ui-text", version.ref = "uiText" }
+foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "androidxFoundation" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
…views; Calendar availability; repos & viewmodels; ApiService updates; strings

## Description
**Host property details overhaul**

- New tabbed views: `Overview.kt`, `Bookings.kt`, `Reviews.kt`, `Calendar.kt`.
- Global pull-to-refresh from anywhere on the screen; each tab reloads its own data.
- Calendar availability: fetches `/api/property/availability/:id` and paints `unavailableDates` in red.
- Repositories & ViewModels: `ReservationRepository`, `AvailabilityRepository`, `ReviewsViewModel` + `ReviewsViewModelFactory`.
- API: extend `ApiService` with reservations/reviews/availability endpoints.
- Strings: tab titles, headers, and user messages.
- Rename: `propertyRepository.kt` → `PropertyRepository.kt` (case fix).
- UX: vertical scroll works across the whole screen; divider added between reviews header and list.

## Related Issue
Closes #<issue-id>

## Type of Change
- [x] 🚀 New feature
- [x] 🐛 Bug fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor
- [ ] ⚙️ Chore

## How Has This Been Tested?
- [x] Manual testing
  - Open a property as **Host**.
  - Pull down **anywhere** → overview stats and the **active tab** refresh.
  - Switch tabs (Overview / Bookings / Reviews / Calendar):
    - **Bookings:** list loads, active counter updates, status chips colors OK; pull-to-refresh works.
    - **Reviews:** average + distribution render; **divider** visible; list scrolls; pull-to-refresh works.
    - **Calendar:** unavailable dates show in red from `/availability/:id`; pull-to-refresh works.
  - No crashes or new warnings in emulator.

## Checklist
- [x] My code follows the project’s coding standards
- [ ] I have added tests to prove my fix/feature works
- [ ] I have updated documentation if needed
- [x] No new warnings or errors were introduced
